### PR TITLE
🐛 fix: replace jcenter with mavenCentral to fix gradle issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ def safeExtGet(prop, fallback) {
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -43,7 +43,7 @@ android {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/OsInfo/android/build.gradle
+++ b/examples/OsInfo/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
+        mavenCentral()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-os",
-  "version": "1.2.7",
+  "version": "1.2.7-cbx.1",
   "description": "node's os module for react-native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- **fix: replace jcenter with mavenCentral to fix gradle issue**
- **chore: bump version to 1.2.7-cbx.1**

 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a build issue by replacing the deprecated JCenter repository with MavenCentral in the Gradle configuration files. This change ensures continued compatibility and successful builds for the Android project.

#### Key Changes
- Replaced `jcenter()` with `mavenCentral()` in the `buildscript` and `allprojects` repositories within `android/build.gradle`.
- Performed the same repository replacement in `examples/OsInfo/android/build.gradle`.
- Updated the package version in `package.json`.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Refactor | 5 (100.0%)    |
| Total Changes | 5         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>